### PR TITLE
closed #12. Fix an error when configuring multiple URIs.

### DIFF
--- a/src/main/resources/jp/ikedam/jenkins/plugins/taglib/form/repeatableTextbox.jelly
+++ b/src/main/resources/jp/ikedam/jenkins/plugins/taglib/form/repeatableTextbox.jelly
@@ -51,7 +51,7 @@ THE SOFTWARE.
 <div class="repeated-container${!empty(header)?' with-drag-drop':''}">
 <!-- The first DIV is the master copy. -->
 <!-- The error message is written into second td, so the first td is dummy. -->
-<div class="repeated-chunk to-be-removed">
+<div class="repeated-chunk to-be-removed" name="">
     <j:if test="${!empty(header)}"><div class="dd-handle">${header}</div></j:if>
     <table style="width: 100%;">
     <tr><td style="display: none;" /><td style="vertical-align: middle; width: 100%;">


### PR DESCRIPTION
Problem occurs only when I add a new URI in the configuration page.
It cannot be reproduced when multiple URIs are registered at the beginning (e.g. by editing the configuration xml directly) and cannot be reproduced in unit tests.

I should use a standard `Describable` container and a standard taglib instead, but this fix doesn't do it and it is left as another issue.
